### PR TITLE
paper-autocomplete-chips in a scrollable parent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,16 +23,17 @@
 	"dependencies": {
 		"polymer": "Polymer/polymer#1.9 - 2",
 		"paper-autocomplete": "^3.2.0",
-		"iron-icon": "PolymerElements/iron-icon#1 - 2"
+		"iron-icon": "PolymerElements/iron-icon#1 - 2",
+		"iron-resizable-behavior": "^2.0.1"
 	},
 	"devDependencies": {
 		"iron-component-page": "PolymerElements/iron-component-page#1 - 3",
 		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
 		"iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
 		"web-component-tester": "^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
-    "paper-dialog": "^2.0.0",
-    "paper-dialog-scrollable": "^2.1.0"
+		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+		"paper-dialog": "^2.0.0",
+		"paper-dialog-scrollable": "^2.1.0"
 	},
 	"variants": {
 		"1.x": {

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,9 @@
 		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
 		"iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
 		"web-component-tester": "^6.0.0",
-		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "paper-dialog": "^2.0.0",
+    "paper-dialog-scrollable": "^2.1.0"
 	},
 	"variants": {
 		"1.x": {

--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,7 @@
 	"dependencies": {
 		"polymer": "Polymer/polymer#1.9 - 2",
 		"paper-autocomplete": "^3.2.0",
-		"iron-icon": "PolymerElements/iron-icon#1 - 2",
-		"iron-resizable-behavior": "^2.0.1"
+		"iron-icon": "PolymerElements/iron-icon#1 - 2"
 	},
 	"devDependencies": {
 		"iron-component-page": "PolymerElements/iron-component-page#1 - 3",

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,10 @@
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="../paper-autocomplete-chips.html">
-
+		
+		<link rel="import" href="../../paper-dialog/paper-dialog.html">
+		<link rel="import" href="../../paper-dialog-scrollable/paper-dialog-scrollable.html">
+		
 		<style is="custom-style" include="demo-pages-shared-styles">
 			div {
 				max-width: 1200px !important;
@@ -22,6 +25,9 @@
 				background-color: red;
 				min-width: 24px;
 				width: 24px;
+			}
+			#t2 {
+				width: 300px;
 			}
 		</style>
 	</head>
@@ -39,6 +45,16 @@
 						id="t2"
 						label="Search 2">
 					</paper-autocomplete-chips>
+					<button onclick="dialog.open()">Open Dialog</button>
+					<paper-dialog id="dialog">
+						<h2>Dialog</h2>
+						<paper-dialog-scrollable>
+							<paper-autocomplete-chips show-results-on-focus
+								id="t3"
+								label="Search 3">
+							</paper-autocomplete-chips>
+						</paper-dialog-scrollable>
+					</paper-dialog>
 			</demo-snippet>
 		</div>
 
@@ -73,6 +89,13 @@
 					'Red',
 					'Green',
 					'Yellow'
+				];
+
+				document.querySelector('#t3').source = [
+					'Red',
+					'Green',
+					'Yellow',
+					'Black'
 				];
 
 				t = new Array(11);

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,45 +16,54 @@
 		
 		<link rel="import" href="../../paper-dialog/paper-dialog.html">
 		<link rel="import" href="../../paper-dialog-scrollable/paper-dialog-scrollable.html">
-		
-		<style is="custom-style" include="demo-pages-shared-styles">
-			div {
-				max-width: 1200px !important;
-			}
-			.box {
-				background-color: red;
-				min-width: 24px;
-				width: 24px;
-			}
-			#t2 {
-				width: 300px;
-			}
-		</style>
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				div {
+					max-width: 1200px !important;
+				}
+				.box {
+					background-color: red;
+					min-width: 24px;
+					width: 24px;
+				}
+				#t2 {
+					width: 300px;
+				}
+
+				#t3 {
+					/* --paper-autocomplete-chips-suggestions-position: fixed; */
+					--paper-autocomplete-chips-suggestions: {
+						position: fixed;
+						width: initial;
+					}
+				}
+			</style>
+		</custom-style>
 	</head>
 	<body>
 		<!-- multi selection selected items -->
 		<div class="vertical-section-container centered">
 			<h4>Basic</h4>
 			<demo-snippet>
-					<paper-autocomplete-chips
-						id="t1"
-						text-property="label"
-						label="Search 1">
-					</paper-autocomplete-chips>
-					<paper-autocomplete-chips
-						id="t2"
-						label="Search 2">
-					</paper-autocomplete-chips>
-					<button onclick="dialog.open()">Open Dialog</button>
-					<paper-dialog id="dialog">
-						<h2>Dialog</h2>
-						<paper-dialog-scrollable>
-							<paper-autocomplete-chips show-results-on-focus
-								id="t3"
-								label="Search 3">
-							</paper-autocomplete-chips>
-						</paper-dialog-scrollable>
-					</paper-dialog>
+				<paper-autocomplete-chips
+					id="t1"
+					text-property="label"
+					label="Search 1">
+				</paper-autocomplete-chips>
+				<paper-autocomplete-chips
+					id="t2"
+					label="Search 2">
+				</paper-autocomplete-chips>
+				<button onclick="dialog.open()">Open Dialog</button>
+				<paper-dialog id="dialog">
+					<h2>Dialog</h2>
+					<paper-dialog-scrollable>
+						<paper-autocomplete-chips show-results-on-focus
+							id="t3"
+							label="Search 3">
+						</paper-autocomplete-chips>
+					</paper-dialog-scrollable>
+				</paper-dialog>
 			</demo-snippet>
 		</div>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,6 +35,7 @@
 					--paper-autocomplete-chips-suggestions: {
 						position: fixed;
 						width: 200px;
+						min-width: initial;
 					};
 				}
 			</style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,11 +31,10 @@
 				}
 
 				#t3 {
-					/* --paper-autocomplete-chips-suggestions-position: fixed; */
 					--paper-autocomplete-chips-suggestions: {
 						position: fixed;
 						width: initial;
-					}
+					};
 				}
 			</style>
 		</custom-style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,9 +31,10 @@
 				}
 
 				#t3 {
+					width: 200px;
 					--paper-autocomplete-chips-suggestions: {
 						position: fixed;
-						width: initial;
+						width: 200px;
 					};
 				}
 			</style>

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -37,7 +37,7 @@ limitations under the License.
   Custom property | Description | Default
   ----------------|-------------|----------
   `--paper-autocomplete-chips-suggestions` | mixin to apply to the suggestions container | `{}`
-  `--paper-autocomplete-chips-suggestions-width` | width of the suggestions container | ``
+  `--paper-autocomplete-chips-suggestions-width` | width of the suggestions container |
   `--paper-autocomplete-chips-suggestions-position` | position of the suggestions container | `absolute`
 
 @demo demo/index.html

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -28,6 +28,18 @@ limitations under the License.
 	<paper-autocomplete-chips label="Search" items='["Red", "Blue", "Green", "Yellow"]'>
 	</paper-autocomplete-chips>
 
+
+  ### Styling
+
+  `<paper-autocomplete-chips>` provides the following custom properties and mixins
+  for styling:
+
+  Custom property | Description | Default
+  ----------------|-------------|----------
+  `--paper-autocomplete-chips-suggestions` | mixin to apply to the suggestions container | `{}`
+  `--paper-autocomplete-chips-suggestions-width` | width of the suggestions container | ``
+  `--paper-autocomplete-chips-suggestions-position` | position of the suggestions container | `absolute`
+
 @demo demo/index.html
 -->
 
@@ -81,7 +93,8 @@ limitations under the License.
 				};
 				--paper-autocomplete-suggestions-wrapper: {
 					position: var(--paper-autocomplete-chips-suggestions-position, absolute);
-					width: var(--paper-autocomplete-chips-suggestions-width, initial);
+					width: var(--paper-autocomplete-chips-suggestions-width);
+					@apply --paper-autocomplete-chips-suggestions;
 				};
 			}
 		</style>

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -18,8 +18,6 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
-
 <link rel="import" href="../paper-autocomplete/paper-autocomplete.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
@@ -82,8 +80,8 @@ limitations under the License.
 					white-space: nowrap;
 				};
 				--paper-autocomplete-suggestions-wrapper: {
-					position: fixed;
-					width: var(--paper-autocomplete-chips-suggestions-wrapper-width, initial);
+					position: var(--paper-autocomplete-chips-suggestions-position, absolute);
+					width: var(--paper-autocomplete-chips-suggestions-width, initial);
 				};
 			}
 		</style>
@@ -111,10 +109,6 @@ limitations under the License.
 		Polymer({
 
 			is: 'paper-autocomplete-chips',
-
-			behaviors: [
-				Polymer.IronResizableBehavior
-			],
 
 			properties: {
 
@@ -268,22 +262,6 @@ limitations under the License.
 					observer: '_selectionChanged'
 				}
 
-			},
-
-			listeners: {
-				'iron-resize': '_onResize'
-			},
-
-			_onResize: function () {
-				const width = `${this.offsetWidth}px`;
-				if (Polymer.Element) {
-					this.updateStyles({
-						'--paper-autocomplete-chips-suggestions-wrapper-width': width,
-					});
-					return;
-				}
-				this.customStyle['--paper-autocomplete-chips-suggestions-wrapper-width'] = width;
-				this.updateStyles();
 			},
 
 			_clearItemSelection: function (event) {

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -264,7 +264,7 @@ limitations under the License.
 
 			},
 
-			_clearItemSelection: function (event, detail) {
+			_clearItemSelection: function (event) {
 				var item = event.model.item,
 					selectedIndex = this.selectedItems.indexOf(item);
 

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -93,7 +93,8 @@ limitations under the License.
 				};
 				--paper-autocomplete-suggestions-wrapper: {
 					position: var(--paper-autocomplete-chips-suggestions-position, absolute);
-					width: var(--paper-autocomplete-chips-suggestions-width);
+					width: var(--paper-autocomplete-chips-suggestions-width, auto);
+					min-width: var(--paper-autocomplete-chips-suggestions-min-width, 100%);
 					@apply --paper-autocomplete-chips-suggestions;
 				};
 			}

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -18,6 +18,8 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
+
 <link rel="import" href="../paper-autocomplete/paper-autocomplete.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
@@ -81,7 +83,7 @@ limitations under the License.
 				};
 				--paper-autocomplete-suggestions-wrapper: {
 					position: fixed;
-					width: initial;
+					width: var(--paper-autocomplete-chips-suggestions-wrapper-width, initial);
 				};
 			}
 		</style>
@@ -109,6 +111,10 @@ limitations under the License.
 		Polymer({
 
 			is: 'paper-autocomplete-chips',
+
+			behaviors: [
+				Polymer.IronResizableBehavior
+			],
 
 			properties: {
 
@@ -262,6 +268,22 @@ limitations under the License.
 					observer: '_selectionChanged'
 				}
 
+			},
+
+			listeners: {
+				'iron-resize': '_onResize'
+			},
+
+			_onResize: function () {
+				const width = `${this.offsetWidth}px`;
+				if (Polymer.Element) {
+					this.updateStyles({
+						'--paper-autocomplete-chips-suggestions-wrapper-width': width,
+					});
+					return;
+				}
+				this.customStyle['--paper-autocomplete-chips-suggestions-wrapper-width'] = width;
+				this.updateStyles();
 			},
 
 			_clearItemSelection: function (event) {

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -80,9 +80,9 @@ limitations under the License.
 					white-space: nowrap;
 				};
 				--paper-autocomplete-suggestions-wrapper: {
-					width: auto;
-					min-width: 100%;
-				}
+					position: fixed;
+					width: initial;
+				};
 			}
 		</style>
 		<div id="chips">


### PR DESCRIPTION
Issue: if parent is scrollable, the suggestions do not overlap the dialog.

![image](https://user-images.githubusercontent.com/5872432/33549596-580a18dc-d8eb-11e7-81bd-dee637b2b813.png)

---
- Added demo with scrollable dialog
- Added mixins to style suggestions-wrapper
---
This issue should actually be solved within `paper-autocomplete` so I created an issue here: https://github.com/ellipticaljs/paper-autocomplete/issues/99 but will only be solved in a breaking change release which could take some time. 
