### PR TITLE
28 - Update to Polymer 2.x - part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
   directories:
   - node_modules
   - bower_components
-  - bower_components-1.x
   - ".eslintcache"
   - "$HOME/.cache/bower"
 before_script:

--- a/bower.json
+++ b/bower.json
@@ -20,45 +20,19 @@
 		"tests"
 	],
 	"dependencies": {
-		"polymer": "Polymer/polymer#1.9 - 2",
+		"polymer": "Polymer/polymer#^2.6.1",
 		"paper-autocomplete": "ellipticaljs/paper-autocomplete#^3.7.0",
 		"iron-icon": "PolymerElements/iron-icon#1 - 2",
 		"cosmoz-i18next": "Neovici/cosmoz-i18next#^1.0.0"
 	},
 	"devDependencies": {
-		"iron-component-page": "PolymerElements/iron-component-page#1 - 3",
-		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
-		"iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
+		"iron-component-page": "PolymerElements/iron-component-page#^3.0.0",
+		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+		"iron-test-helpers": "PolymerElements/iron-test-helpers#^2.0.0",
 		"web-component-tester": "^6.0.0",
 		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
 		"paper-dialog": "^2.0.0",
 		"paper-dialog-scrollable": "^2.1.0"
-	},
-	"variants": {
-		"1.x": {
-			"dependencies": {
-				"polymer": "Polymer/polymer#^1.9.0",
-				"paper-autocomplete": "ellipticaljs/paper-autocomplete#^3.7.0",
-				"iron-icon": "PolymerElements/iron-icon#^1.0.13",
-				"cosmoz-i18next": "Neovici/cosmoz-i18next#^1.0.0"
-			},
-			"devDependencies": {
-				"iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
-				"iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.2.6",
-				"iron-test-helpers": "PolymerElements/iron-test-helpers#^1.4.1",
-				"web-component-tester": "^4.0.0",
-				"webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
-			},
-			"resolutions": {
-				"webcomponentsjs": "^0.7.0",
-				"iron-icon": "^1.0.13",
-				"iron-icons": "^1.2.1",
-				"iron-iconset-svg": "^1.1.1",
-				"iron-flex-layout": "^1.3.7",
-				"paper-icon-button": "^1.1.6",
-				"paper-ripple": "^1.0.10"
-			}
-		}
 	},
 	"resolutions": {
 		"webcomponentsjs": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"start": "polymer serve -o",
 		"preinstall": "rm -f package-lock.json",
-		"postinstall": "polymer install --variants && yarn sync-npm",
+		"postinstall": "polymer install && yarn sync-npm",
 		"lint": "eslint --cache --ext .js,.html . && polymer lint paper-*.html",
 		"test": "polymer test",
 		"analyze": "polymer analyze --input cosmoz-*.html  > analysis.json",

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../polymer/polymer.html">
-
+<link rel="import" href="../shadycss/apply-shim.html">
+<link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-autocomplete/paper-autocomplete.html">
 <link rel="import" href="../paper-item/paper-item.html">
@@ -112,8 +112,8 @@ limitations under the License.
 			<slot name="prefix" slot="prefix"></slot>
 			<slot name="suffix" slot="suffix"></slot>
 			<template slot="autocomplete-custom-template">
-				<paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false" on-tap="_onSelect">
-					<div inner-h-t-m-l="[[item.html]]"></div>
+				<paper-item id$="[[ _getSuggestionId(index) ]]" role="option" aria-selected="false" on-tap="_onSelect">
+					<div inner-h-t-m-l="[[ item.html ]]"></div>
 					<paper-ripple></paper-ripple>
 				</paper-item>
 			  </template>
@@ -122,11 +122,12 @@ limitations under the License.
 
 	<script type="text/javascript">
 
-		Polymer({
-
-			is: 'paper-autocomplete-chips',
-
-			properties: {
+	class PaperAutocompleteChips extends Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element) {
+		static get is() {
+			return 'paper-autocomplete-chips';
+		}
+		static get properties() {
+			return {
 
 				/**
 				 * `<paper-autocomplete>`/`<paper-input>` `label`
@@ -197,8 +198,8 @@ limitations under the License.
 				 */
 				queryFn: {
 					type: Function,
-					value: function () {
-						var me = this,
+					value() {
+						const me = this,
 							maxResults = 30,
 							regexpResult = '<b>$1</b>',
 							getResult = (item, textProp) => {
@@ -260,7 +261,7 @@ limitations under the License.
 									break;
 								}
 							}
-							return results.sort(function (a, b) {
+							return results.sort((a, b) => {
 								if (a.idx < b.idx) {
 									return -1;
 								}
@@ -285,7 +286,7 @@ limitations under the License.
 				selectedItems: {
 					type: Array,
 					notify: true,
-					value: function () {
+					value() {
 						return [];
 					}
 				},
@@ -345,69 +346,88 @@ limitations under the License.
 					observer: '_selectionChanged'
 				}
 
-			},
-			behaviors: [
-				Cosmoz.TranslatableBehavior
-			],
-			_clearItemSelection(event) {
-				var item = event.model.item,
-					selectedIndex = this.selectedItems.indexOf(item);
+			};
+		}
+		constructor() {
+			super();
+		}
+		/**
+		 * Clear the selected items.
+		 * @param {object} event Polymer event object.
+		 * @returns {void}
+		 */
+		_clearItemSelection(event) {
+			const item = event.model.item,
+				selectedIndex = this.selectedItems.indexOf(item);
 
-				// This will remove from the DOM the source element of the processed event ...
-				this.splice('selectedItems', selectedIndex, 1);
-				// ... so we must prevent further propagation of this event, because its source is now invalid.
-				// (This has caused troubles in app-drawer-layout click event handler).
-				event.preventDefault();
-				event.stopPropagation();
-			},
-
-			_getChipText(item, textProperty) {
-				if (typeof item === 'object') {
-					return this.get(textProperty, item) || item.text;
-				}
-				return item;
-			},
-
-			_selectionChanged(newSelection) {
-				if (newSelection === null) {
-					return;
-				}
-				this.push('selectedItems', newSelection);
-				this.async(function () {
-					this.$.ac.clear();
-
-					// FIXME
-					this.$.ac.$.paperAutocompleteSuggestions._handleSuggestions({
-						target: {
-							value: ''
-						}
-					});
-				});
-			},
-
-			validate() {
-				if (this.required && this.selectedItems.length === 0) {
-					this.set('_acInvalid', true);
-					this.set('errorMessage', this.gettext('Something must be selected in the list.'));
-					return false;
-				}
-
-				if (this.min && this.min > this.selectedItems.length) {
-					this.set('_acInvalid', true);
-					this.set('errorMessage', this.gettext('Select at least {0} in the list.', this.min));
-					return false;
-				}
-
-				if (this.max && this.max < this.selectedItems.length) {
-					this.set('_acInvalid', true);
-					this.set('errorMessage', this.gettext('Select maximum {0} in the list.', this.max));
-					return false;
-				}
-
-				this.set('_acInvalid', false);
-				this.set('errorMessage', '');
-				return true;
+			// This will remove from the DOM the source element of the processed event ...
+			this.splice('selectedItems', selectedIndex, 1);
+			// ... so we must prevent further propagation of this event, because its source is now invalid.
+			// (This has caused troubles in app-drawer-layout click event handler).
+			event.preventDefault();
+			event.stopPropagation();
+		}
+		/**
+		 * Get text for the chip labels.
+		 * @param {object} item Item.
+		 * @param {string} textProperty Property in the item where the text is located.
+		 * @returns {void}
+		 */
+		_getChipText(item, textProperty) {
+			if (typeof item === 'object') {
+				return this.get(textProperty, item) || item.text;
 			}
-		});
+			return item;
+		}
+		/**
+		 * Update the selected items and request handle of suggestions.
+		 * @param {object} newSelection Selected item.
+		 * @returns {void}
+		 */
+		_selectionChanged(newSelection) {
+			if (newSelection === null) {
+				return;
+			}
+			this.push('selectedItems', newSelection);
+			this.async(function () {
+				this.$.ac.clear();
+
+				// FIXME
+				this.$.ac.$.paperAutocompleteSuggestions._handleSuggestions({
+					target: {
+						value: ''
+					}
+				});
+			});
+		}
+		/**
+		 * Check whether the input is valid or not.
+		 * @returns {boolean}
+		 */
+		validate() {
+			if (this.required && this.selectedItems.length === 0) {
+				this.set('_acInvalid', true);
+				this.set('errorMessage', this.gettext('Something must be selected in the list.'));
+				return false;
+			}
+
+			if (this.min && this.min > this.selectedItems.length) {
+				this.set('_acInvalid', true);
+				this.set('errorMessage', this.gettext('Select at least {0} in the list.', this.min));
+				return false;
+			}
+
+			if (this.max && this.max < this.selectedItems.length) {
+				this.set('_acInvalid', true);
+				this.set('errorMessage', this.gettext('Select maximum {0} in the list.', this.max));
+				return false;
+			}
+
+			this.set('_acInvalid', false);
+			this.set('errorMessage', '');
+			return true;
+		}
+	}
+	customElements.define(PaperAutocompleteChips.is, PaperAutocompleteChips);
 	</script>
 </dom-module>

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -240,7 +240,7 @@ limitations under the License.
 									continue;
 								}
 
-								let result = getResult(item, this.textProperty);
+								let result = getResult(item, me.textProperty);
 
 								if (result == null) {
 									continue;
@@ -398,11 +398,11 @@ limitations under the License.
 						value: ''
 					}
 				});
-			});
+			}.bind(this));
 		}
 		/**
 		 * Check whether the input is valid or not.
-		 * @returns {boolean}
+		 * @returns {boolean} Whether the input is valid or not.
 		 */
 		validate() {
 			if (this.required && this.selectedItems.length === 0) {

--- a/polymer.json
+++ b/polymer.json
@@ -1,5 +1,5 @@
 {
 	"lint": {
-		"rules": ["polymer-2-hybrid"]
+		"rules": ["polymer-2"]
 	}
 }

--- a/test/basic.html
+++ b/test/basic.html
@@ -48,11 +48,6 @@
 					});
 				});
 
-				test('Instantiates a paper-autocomplete-chips instance', done => {
-					assert.equal(chips.is, 'paper-autocomplete-chips');
-					done();
-				});
-
 				test('Selecting string source', done => {
 					chips.source = ['A', 'B', 'C'];
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -49,7 +49,7 @@
 				});
 
 				test('Instantiates a paper-autocomplete-chips instance', done => {
-					assert.equal(chips.is(), 'paper-autocomplete-chips');
+					assert.equal(chips.is, 'paper-autocomplete-chips');
 					done();
 				});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -49,7 +49,7 @@
 				});
 
 				test('Instantiates a paper-autocomplete-chips instance', done => {
-					assert.equal(chips.is, 'paper-autocomplete-chips');
+					assert.equal(chips.is(), 'paper-autocomplete-chips');
 					done();
 				});
 


### PR DESCRIPTION
Update to Polymer 2.x - part 2.

* Removed variants.
* Updated version masks to ^2.0.0.
* Changed to arrow functions.
* Updated to ES6 class syntax.

Followed changes mostly in https://github.com/Neovici/cosmoz-datetime-input/pull/10 but also some from https://www.polymer-project.org/2.0/docs/upgrade.

Issue is #28.