### PR TITLE
28 - Update to Polymer 2.x - part 3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"polymer": "Polymer/polymer#^2.6.1",
 		"paper-autocomplete": "ellipticaljs/paper-autocomplete#^3.7.0",
-		"iron-icon": "PolymerElements/iron-icon#1 - 2",
+		"iron-icon": "PolymerElements/iron-icon#^2.1.0",
 		"cosmoz-i18next": "Neovici/cosmoz-i18next#^1.0.0"
 	},
 	"devDependencies": {

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,7 +17,7 @@
 		<link rel="import" href="../../paper-dialog/paper-dialog.html">
 		<link rel="import" href="../../paper-dialog-scrollable/paper-dialog-scrollable.html">
 		<custom-style>
-			<style is="custom-style" include="demo-pages-shared-styles">
+			<style include="demo-pages-shared-styles">
 				div {
 					max-width: 1200px !important;
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2062,13 +2062,6 @@
 			"version": "2.0.0",
 			"dev": true
 		},
-		"cli": {
-			"version": "1.0.1",
-			"requires": {
-				"exit": "0.1.2",
-				"glob": "^7.1.1"
-			}
-		},
 		"cli-boxes": {
 			"version": "1.0.0",
 			"dev": true
@@ -3152,9 +3145,6 @@
 				}
 			}
 		},
-		"exit": {
-			"version": "0.1.2"
-		},
 		"exit-hook": {
 			"version": "1.1.1",
 			"dev": true
@@ -3773,7 +3763,8 @@
 			"dev": true
 		},
 		"fs.realpath": {
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.3.1",
@@ -3884,6 +3875,7 @@
 		},
 		"glob": {
 			"version": "7.1.3",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -7201,12 +7193,6 @@
 				"@types/node": "*"
 			}
 		},
-		"ruby": {
-			"version": "0.6.1",
-			"requires": {
-				"lodash": "^4.13.0"
-			}
-		},
 		"run-async": {
 			"version": "2.3.0",
 			"dev": true,
@@ -8115,9 +8101,6 @@
 					"dev": true
 				}
 			}
-		},
-		"travis": {
-			"version": "0.1.1"
 		},
 		"trim-newlines": {
 			"version": "1.0.0",

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -387,7 +387,7 @@ limitations under the License.
 				return;
 			}
 			this.push('selectedItems', newSelection);
-			Polymer.Async.microTask.run(function () {
+			Polymer.Async.microTask.run(() => {
 				this.$.ac.clear();
 				// FIXME
 				this.$.ac.$.paperAutocompleteSuggestions._handleSuggestions({
@@ -395,7 +395,7 @@ limitations under the License.
 						value: ''
 					}
 				});
-			}.bind(this));
+			});
 		}
 		/**
 		 * Check whether the input is valid or not.

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -348,9 +348,6 @@ limitations under the License.
 
 			};
 		}
-		constructor() {
-			super();
-		}
 		/**
 		 * Clear the selected items.
 		 * @param {object} event Polymer event object.

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -22,6 +22,7 @@ limitations under the License.
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../cosmoz-i18next/cosmoz-i18next.html">
+<link rel="import" href="/bower_components/polymer/lib/utils/async.html">
 
 <!--
 `paper-autocomplete-chips` is a multi-selection autocomplete element.
@@ -386,9 +387,8 @@ limitations under the License.
 				return;
 			}
 			this.push('selectedItems', newSelection);
-			this.async(function () {
+			Polymer.Async.microTask.run(function () {
 				this.$.ac.clear();
-
 				// FIXME
 				this.$.ac.$.paperAutocompleteSuggestions._handleSuggestions({
 					target: {

--- a/test/basic.html
+++ b/test/basic.html
@@ -112,7 +112,7 @@
 					chips.textProperty = 'label';
 					autocomplete.text = 'a';
 
-					Polymer.Async.microTask.run(() => {
+					window.setTimeout(() => {
 						assert.equal(suggestions._suggestions.length, 3);
 						done();
 					}, 200);

--- a/test/basic.html
+++ b/test/basic.html
@@ -12,6 +12,7 @@
 		<link rel="import" href="../../test-fixture/test-fixture.html">
 		<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
 		<link rel="import" href="../paper-autocomplete-chips.html">
+		<link rel="import" href="/bower_components/polymer/lib/utils/async.html">
 	</head>
 	<body>
 		<test-fixture id="defaults">
@@ -30,7 +31,7 @@
 						// Set input value
 						autocomplete.text = value.toString();
 						// Trigger create suggestions
-						suggestions.dispatchEvent(new CustomEvent('keyup', { bubbles: true, composed: true }));
+						suggestions._input.dispatchEvent(new CustomEvent('keyup', { bubbles: true, composed: true }));
 						// Select first result
 						suggestions._selection(0);
 					},
@@ -43,9 +44,7 @@
 					chips = fixture('defaults');
 					autocomplete = chips.$.ac;
 					suggestions = autocomplete.$.paperAutocompleteSuggestions;
-					Polymer.Base.async(() => {
-						done();
-					});
+					Polymer.Async.microTask.run(() => done());
 				});
 
 				test('Selecting string source', done => {
@@ -113,12 +112,12 @@
 					chips.textProperty = 'label';
 					autocomplete.text = 'a';
 
-					Polymer.Base.async(() => {
+					Polymer.Async.microTask.run(() => {
 						assert.equal(suggestions._suggestions.length, 3);
 						done();
 					}, 200);
 
-					suggestions.dispatchEvent(new CustomEvent('focus', { bubbles: true, composed: true }));
+					suggestions._input.dispatchEvent(new CustomEvent('focus', { bubbles: true, composed: true }));
 
 					chips.source = [
 						{value: 0, label: 'ab'},

--- a/test/basic.html
+++ b/test/basic.html
@@ -30,7 +30,7 @@
 						// Set input value
 						autocomplete.text = value.toString();
 						// Trigger create suggestions
-						suggestions._input.fire('keyup');
+						suggestions.dispatchEvent(new CustomEvent('keyup', { bubbles: true, composed: true }));
 						// Select first result
 						suggestions._selection(0);
 					},
@@ -118,7 +118,7 @@
 						done();
 					}, 200);
 
-					suggestions._input.fire('focus', {});
+					suggestions.dispatchEvent(new CustomEvent('focus', { bubbles: true, composed: true }));
 
 					chips.source = [
 						{value: 0, label: 'ab'},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2213,14 +2213,6 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-cli@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cli/-/cli-1.0.1.tgz#22817534f24bfa4950c34d532d48ecbc621b8c14"
-  integrity sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=
-  dependencies:
-    exit "0.1.2"
-    glob "^7.1.1"
-
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -3348,11 +3340,6 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
   integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
-
-exit@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -4997,7 +4984,7 @@ istanbul@0.3.*:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-istanbul@^0.4.0, istanbul@^0.4.5:
+istanbul@^0.4.0:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
   integrity sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
@@ -5318,7 +5305,7 @@ lodash@^3.0.0, lodash@^3.10.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.0, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.8.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -7174,13 +7161,6 @@ rollup@^0.64.1:
     "@types/estree" "0.0.39"
     "@types/node" "*"
 
-ruby@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/ruby/-/ruby-0.6.1.tgz#b3fee5787e4f9c0d5814d6166a5b5dbcfb24ba35"
-  integrity sha1-s/7leH5PnA1YFNYWaltdvPskujU=
-  dependencies:
-    lodash "^4.13.0"
-
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -8157,11 +8137,6 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
-
-travis@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/travis/-/travis-0.1.1.tgz#80fe1c36f6f3b739fce07e6063838ce436357d60"
-  integrity sha1-gP4cNvbztzn84H5gY4OM5DY1fWA=
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Update to Polymer 2.x - part 3.

* Removing unnecessary constructor.
* Replacing `fire` with `dispatchEvent` in tests.
* Removing `is` attribute from style in `custom-style`.

Not sure if the dom-repeat template should be wrapped in `dom-repeat`.

I am also welcoming suggestions on more things to convert in this component, if there are any.

Issue is #28.