### PR TITLE
35 - Sanitize RegExp input when highlighting suggestions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,7 +87,13 @@
 		"no-use-before-define": "error",
 		"no-useless-call": "error",
 		"no-useless-concat": "error",
-		"one-var": "error",
+		"one-var": [
+			"error",
+			{
+				"var": "always",
+				"let": "always"
+			}
+		],
 		"one-var-declaration-per-line": [
 			"error",
 			"always"

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -255,7 +255,8 @@ limitations under the License.
 									continue;
 								}
 
-								result.html = result.text.replace(new RegExp('(' + query.replace(/[|\\{}()[\]^$+*?.-]/gu, '\\$&') + ')', 'ig'), regexpResult);
+								const escapedQuery = query.replace(/[|\\{}()[\]^$+*?.-]/gu, '\\$&');
+								result.html = result.text.replace(new RegExp('(' + escapedQuery + ')', 'ig'), regexpResult);
 								results.push(result);
 
 								if (results.length >= maxResults) {

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -255,7 +255,7 @@ limitations under the License.
 									continue;
 								}
 
-								result.html = result.text.replace(new RegExp('(' + query + ')', 'ig'), regexpResult);
+								result.html = result.text.replace(new RegExp('(' + query.replace(/[|\\{}()[\]^$+*?.-]/gu, '\\$&') + ')', 'ig'), regexpResult);
 								results.push(result);
 
 								if (results.length >= maxResults) {


### PR DESCRIPTION
Sanitize RegExp input when highlighting suggestions.

Test by entering some regular expression interfering characters like `(`, `)` and so on. No error should appear in console when doing so.

Issue is #35.