### PR TITLE
Replacing translation behavior with mixin, upgrading cosmoz-i18next component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
 		"polymer": "Polymer/polymer#^2.6.1",
 		"paper-autocomplete": "ellipticaljs/paper-autocomplete#^3.7.0",
 		"iron-icon": "PolymerElements/iron-icon#^2.1.0",
-		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.0"
+		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.1"
 	},
 	"devDependencies": {
 		"iron-component-page": "PolymerElements/iron-component-page#^3.0.0",

--- a/paper-autocomplete-chips.html
+++ b/paper-autocomplete-chips.html
@@ -122,8 +122,8 @@ limitations under the License.
 	</template>
 
 	<script type="text/javascript">
-
-	class PaperAutocompleteChips extends Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element) {
+	/*global Cosmoz*/
+	class PaperAutocompleteChips extends Cosmoz.Mixins.translatable(Polymer.Element) {
 		static get is() {
 			return 'paper-autocomplete-chips';
 		}


### PR DESCRIPTION
Replacing translation behavior with mixin, upgrading cosmoz-i18next component.

Had to upgrade the component because the mixin is in `cosmoz-i18next^2.0.1`.

Testing, `yarn install; yarn start`.

Build errors are Chrome 74-76 errors.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.