### PR TITLE
feat: Tooltip for chips. 

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -88,19 +88,24 @@
 			}, {
 				id: 'six',
 				label: 'Black selection'
+			}, {
+				id: 'seven',
+				label: ''
 			}];
 
 			document.querySelector('#t2').source = [
 				'Red',
 				'Green',
-				'Yellow'
+				'Yellow',
+				''
 			];
 
 			document.querySelector('#t3').source = [
 				'Red',
 				'Green',
 				'Yellow',
-				'Black'
+				'Black',
+				''
 			];
 		</script>
 	</body>


### PR DESCRIPTION
refs https://github.com/Neovici/paper-autocomplete-chips/issues/49

Adds tooltip text functionality to the chips. When an chip is empty, it hides all text, only showing the remove icon. However it will still have an tool tip with the no value label. 

I updated the demo, so testing can be done there. 